### PR TITLE
(SLV-336) Set hiera.yaml to be used by environment

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -5,7 +5,7 @@ hierarchy:
     data_hash: classifier_data
   - name: Yaml backend
     data_hash: yaml_data
-    datadir: "/etc/puppetlabs/code/environments/production/hieradata/"
+    datadir: "hieradata"
     paths:
       - "vagrant/%{is_vagrant}.yaml"
       - "nodes/%{fake_domain}/%{fqdn}.yaml"


### PR DESCRIPTION
This commit moves the `hiera.yaml` file to the root of the control repo
and sets the `datadir` value to a relative path.  This will allow the
file to be used in any environment deployed via a branch of this repo by
r10k.