### PR TITLE
(SLV-629) Remove params to puppet metrics collector

### DIFF
--- a/site-modules/profile/manifests/puppet_master.pp
+++ b/site-modules/profile/manifests/puppet_master.pp
@@ -1,8 +1,5 @@
 class profile::puppet_master {
 
-  class { 'puppet_metrics_collector':
-    puppetserver_hosts => [ $trusted['certname'] ],
-    puppetdb_hosts     => [ $trusted['certname'] ],
-  }
+  include puppet_metrics_collector
 
 }


### PR DESCRIPTION
This lets the default be, which correctly auto detect the hosts with the services installed
Makes it work with large ref arch

tested with both large and standard ref arch