### PR TITLE
(SLV-695) Quote integers where need to be strings

### DIFF
--- a/site-modules/profile/manifests/loop_through_file_resources.pp
+++ b/site-modules/profile/manifests/loop_through_file_resources.pp
@@ -8,7 +8,7 @@ class profile::loop_through_file_resources {
   $my_array.each | $num | {
     $more_num = $num + 1
 
-    file_line { $num :
+    file_line { "${num}" :
       path => $file,
       line => "${num}=${more_num}",
     }
@@ -16,12 +16,12 @@ class profile::loop_through_file_resources {
     $num_num = $num + 200
     $num_num_num = $num + 250
 
-    ini_setting { $num :
+    ini_setting { "${num}" :
       ensure  => present,
       path    => $file,
       section => 'default',
-      setting => $num_num,
-      value   => $num_num_num,
+      setting => "${num_num}",
+      value   => "${num_num_num}",
     }
   }
 }


### PR DESCRIPTION
This commit quotes integer values used in the
`fix_through_file_resources.pp` manifest for parameters that expect
strings.  This change triggers erroneous puppet-lint warnings, but the
check is left in place to catch occurrences where a single string is
quoted.